### PR TITLE
Create Release CI

### DIFF
--- a/.github/workflows/on_unpoller_release.yaml
+++ b/.github/workflows/on_unpoller_release.yaml
@@ -26,6 +26,9 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: yq - portable yaml processor
+        uses: mikefarah/yq@v4.43.1
+
       - name: Update helm values
         run: |
           UNPOLLER_VERSION=${{ workflow.inputs.unpoller_version }}

--- a/.github/workflows/on_unpoller_release.yaml
+++ b/.github/workflows/on_unpoller_release.yaml
@@ -1,5 +1,4 @@
-name: On Unpoller release
-
+name: OnUnpollerRelease
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/on_unpoller_release.yaml
+++ b/.github/workflows/on_unpoller_release.yaml
@@ -36,7 +36,7 @@ jobs:
           yq -i ".image.tag=\"${UNPOLLER_VERSION}\"" charts/unpoller/values.yaml
           make helm-docs
           
-          charts/unpoller/README.md README.MD
+          cp charts/unpoller/README.md README.MD
           git add charts
           git add README.MD         
           git commit -m "chore(unpoller): Updated chart and app version to ${UNPOLLER_VERSION}}"

--- a/.github/workflows/on_unpoller_release.yaml
+++ b/.github/workflows/on_unpoller_release.yaml
@@ -1,0 +1,41 @@
+name: On Unpoller release
+
+on:
+  workflow_dispatch:
+    inputs:
+      unpoller_version:
+        description: 'Version of unpoller released'
+        required: true
+        type: string
+
+jobs:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Update helm values
+        run: |
+          UNPOLLER_VERSION=${{ workflow.inputs.unpoller_version }}
+          yq -i ".appVersion=\"${UNPOLLER_VERSION}\"" charts/unpoller/Chart.yaml
+          yq -i ".version=\"${UNPOLLER_VERSION}\"" charts/unpoller/Chart.yaml
+           yq -i ".image.tag=\"${UNPOLLER_VERSION}\"" charts/unpoller/values.yaml
+          make helm-docs
+          
+          charts/unpoller/README.md README.MD
+          git add charts
+          git add README.MD         
+          git commit -m "chore(unpoller): Updated chart and app version to ${UNPOLLER_VERSION}}"
+          git push

--- a/.github/workflows/on_unpoller_release.yaml
+++ b/.github/workflows/on_unpoller_release.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Update helm values
         run: |
-          UNPOLLER_VERSION=${{ workflow.inputs.unpoller_version }}
+          UNPOLLER_VERSION=${{ github.event.inputs.unpoller_version }}
           yq -i ".appVersion=\"${UNPOLLER_VERSION}\"" charts/unpoller/Chart.yaml
           yq -i ".version=\"${UNPOLLER_VERSION}\"" charts/unpoller/Chart.yaml
           yq -i ".image.tag=\"${UNPOLLER_VERSION}\"" charts/unpoller/values.yaml

--- a/.github/workflows/on_unpoller_release.yaml
+++ b/.github/workflows/on_unpoller_release.yaml
@@ -34,7 +34,7 @@ jobs:
           UNPOLLER_VERSION=${{ workflow.inputs.unpoller_version }}
           yq -i ".appVersion=\"${UNPOLLER_VERSION}\"" charts/unpoller/Chart.yaml
           yq -i ".version=\"${UNPOLLER_VERSION}\"" charts/unpoller/Chart.yaml
-           yq -i ".image.tag=\"${UNPOLLER_VERSION}\"" charts/unpoller/values.yaml
+          yq -i ".image.tag=\"${UNPOLLER_VERSION}\"" charts/unpoller/values.yaml
           make helm-docs
           
           charts/unpoller/README.md README.MD

--- a/.github/workflows/on_unpoller_release.yaml
+++ b/.github/workflows/on_unpoller_release.yaml
@@ -33,7 +33,6 @@ jobs:
           UNPOLLER_VERSION=${{ github.event.inputs.unpoller_version }}
           yq -i ".appVersion=\"${UNPOLLER_VERSION}\"" charts/unpoller/Chart.yaml
           yq -i ".version=\"${UNPOLLER_VERSION}\"" charts/unpoller/Chart.yaml
-          yq -i ".image.tag=\"${UNPOLLER_VERSION}\"" charts/unpoller/values.yaml
           make helm-docs
           
           cp charts/unpoller/README.md README.MD

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    # run only against tags
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/unpoller/values.yaml
+++ b/charts/unpoller/values.yaml
@@ -7,7 +7,7 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   # this is set to the major version compatible, if you want to pin this, you must override it
-  tag: "v2"
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Two workflows added:
OnUnpollerRelease: Add a GH workflow (to be invoked from unpoller repo) that will update the image versions whenever a release is generated. Still tagging the main branch with the tag received from unpoller is not done, to test each step individually.

Release: pushes the index.yam and creates the release (with the chart) as GH release.

** **This PR requires activating the Github pages functionality on settings of this repo** ** the expected branch is the default gh-pages. I don't have admin permissions on the repo so I can't do it myself. see instructions: https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-github-pages-site

companion PR: https://github.com/unpoller/unpoller/pull/710

I triggered this on my fork, seems to be working fine: https://github.com/jlpedrosa/helm-chart/actions/runs/8973444825/job/24643627154

