### PR TITLE
Update docs -  ci

### DIFF
--- a/.github/workflows/on_unpoller_release.yaml
+++ b/.github/workflows/on_unpoller_release.yaml
@@ -31,8 +31,9 @@ jobs:
       - name: Update helm values
         run: |
           UNPOLLER_VERSION=${{ github.event.inputs.unpoller_version }}
+          CHART_VERSION="${UNPOLLER_VERSION:1}"
           yq -i ".appVersion=\"${UNPOLLER_VERSION}\"" charts/unpoller/Chart.yaml
-          yq -i ".version=\"${UNPOLLER_VERSION}\"" charts/unpoller/Chart.yaml
+          yq -i ".version=\"${CHART_VERSION}\"" charts/unpoller/Chart.yaml
           make helm-docs
           
           cp charts/unpoller/README.md README.MD

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.cr-release-packages/
+/.crindex/
+.vscode
+.idea

--- a/charts/unpoller/Chart.yaml
+++ b/charts/unpoller/Chart.yaml
@@ -14,7 +14,7 @@ description: |
   **Note**: *This is a best effort to keep this chart working for kubernetes.*
 
 type: application
-version: "2.11.2"
+version: "2.11.2+Chart1"
 appVersion: "2.11.2"
 keywords:
   - unifi

--- a/charts/unpoller/Chart.yaml
+++ b/charts/unpoller/Chart.yaml
@@ -1,6 +1,18 @@
 apiVersion: v2
 name: unpoller
-description: "A Helm chart for unpoller, a unifi prometheus exporter. This chart helps deploy Unpoller (unifi metrics exporter)\nin kubernetes clusters. \nIt crates a Deployment to run the unpoller container, confiuration is stored in a ConfigMap and mounted in the container.\nIt supports integration with Prometheus operator, so a PodMonitor is created that will scrape the Deployment for the metrics.\nOptionally, it can deploy automatically the dashboards into a Grafana instance through the integration with GrafanaOperator:\n* Creates a Grafana CR with the credentials provided (or reuses existing Grafana object)\n* Creates a Dashboard instance for all the unpoller provided charts.\nSee Readme.MD for details, and values.yaml for all the configuration options.\n\nSee further documentation in how to install unpoller in Kubernetes in https://unpoller.com/PATH_TBD (will be updated)\n"
+description: |
+  A Helm chart for unpoller, a unifi prometheus exporter. This chart helps deploy Unpoller (unifi metrics exporter)
+  in kubernetes clusters. 
+  It crates a Deployment to run the unpoller container, confiuration is stored in a ConfigMap and mounted in the container.
+  It supports integration with Prometheus operator, so a PodMonitor is created that will scrape the Deployment for the metrics.
+  Optionally, it can deploy automatically the dashboards into a Grafana instance through the integration with GrafanaOperator:
+  * Creates a Grafana CR with the credentials provided (or reuses existing Grafana object)
+  * Creates a Dashboard instance for all the unpoller provided charts.
+  
+  See further documentation in how to install unpoller in Kubernetes in http://unpoller.github.io/helm-chart 
+  
+  **Note**: *This is a best effort to keep this chart working for kubernetes.*
+
 type: application
 version: "2.11.2"
 appVersion: "2.11.2"
@@ -11,4 +23,4 @@ keywords:
   - prometheus
 home: https://unpoller.com/
 sources:
-  - https://github.com/unpoller/unpoller
+  - https://github.com/unpoller/helm-chart

--- a/charts/unpoller/README.md
+++ b/charts/unpoller/README.md
@@ -11,7 +11,7 @@ Optionally, it can deploy automatically the dashboards into a Grafana instance t
 * Creates a Dashboard instance for all the unpoller provided charts.
 See Readme.MD for details, and values.yaml for all the configuration options.
 
-See further documentation in how to install unpoller in Kubernetes in https://unpoller.com/PATH_TBD (will be updated)
+See further documentation in how to install unpoller in Kubernetes in http://unpoller.github.io/helm-chart (will be updated)
 
 **Homepage:** <https://unpoller.com/>
 

--- a/charts/unpoller/templates/deployment.yaml
+++ b/charts/unpoller/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
       volumes:
         - name: config-volume
           secret:
-            secretName: unifi-poller
+            secretName: {{ include "unpoller.fullname" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Strip v from the tag received from unpoller main repo, so chart versions don't contain v (can cause issues)
Update docs with the final URL for the helm repository.
Fixes on the chart, Secret name is not marching config.
Add .gitignore
Update chart version.