### PR TITLE
fix(chart): Default grafana user in k8s + secret names

### DIFF
--- a/.github/workflows/on_unpoller_release.yaml
+++ b/.github/workflows/on_unpoller_release.yaml
@@ -31,9 +31,8 @@ jobs:
       - name: Update helm values
         run: |
           UNPOLLER_VERSION=${{ github.event.inputs.unpoller_version }}
-          CHART_VERSION="${UNPOLLER_VERSION:1}"
           yq -i ".appVersion=\"${UNPOLLER_VERSION}\"" charts/unpoller/Chart.yaml
-          yq -i ".version=\"${CHART_VERSION}\"" charts/unpoller/Chart.yaml
+          yq -i ".version=\"${UNPOLLER_VERSION}\"" charts/unpoller/Chart.yaml
           make helm-docs
           
           cp charts/unpoller/README.md README.MD

--- a/charts/unpoller/Chart.yaml
+++ b/charts/unpoller/Chart.yaml
@@ -14,8 +14,8 @@ description: |
   **Note**: *This is a best effort to keep this chart working for kubernetes.*
 
 type: application
-version: "2.11.2-Chart4"
-appVersion: "2.11.2"
+version: "2.11.2-Chart5"
+appVersion: "v2.11.2"
 keywords:
   - unifi
   - unpoller

--- a/charts/unpoller/README.md
+++ b/charts/unpoller/README.md
@@ -1,6 +1,6 @@
 # unpoller
 
-![Version: 2.11.2](https://img.shields.io/badge/Version-2.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.11.2](https://img.shields.io/badge/AppVersion-2.11.2-informational?style=flat-square)
+![Version: 2.11.2-Chart5](https://img.shields.io/badge/Version-2.11.2--Chart5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.11.2](https://img.shields.io/badge/AppVersion-v2.11.2-informational?style=flat-square)
 
 A Helm chart for unpoller, a unifi prometheus exporter. This chart helps deploy Unpoller (unifi metrics exporter)
 in kubernetes clusters.
@@ -9,15 +9,16 @@ It supports integration with Prometheus operator, so a PodMonitor is created tha
 Optionally, it can deploy automatically the dashboards into a Grafana instance through the integration with GrafanaOperator:
 * Creates a Grafana CR with the credentials provided (or reuses existing Grafana object)
 * Creates a Dashboard instance for all the unpoller provided charts.
-See Readme.MD for details, and values.yaml for all the configuration options.
 
-See further documentation in how to install unpoller in Kubernetes in http://unpoller.github.io/helm-chart (will be updated)
+See further documentation in how to install unpoller in Kubernetes in http://unpoller.github.io/helm-chart
+
+**Note**: *This is a best effort to keep this chart working for kubernetes.*
 
 **Homepage:** <https://unpoller.com/>
 
 ## Source Code
 
-* <https://github.com/unpoller/unpoller>
+* <https://github.com/unpoller/helm-chart>
 
 ## Values
 
@@ -28,7 +29,7 @@ See further documentation in how to install unpoller in Kubernetes in http://unp
 | dashboards.grafana.create | bool | `true` |  |
 | dashboards.grafana.secret.existingSecretName | string | `""` |  |
 | dashboards.grafana.secret.password | string | `"prom-operator"` |  |
-| dashboards.grafana.secret.username | string | `"prom"` |  |
+| dashboards.grafana.secret.username | string | `"admin"` |  |
 | dashboards.grafana.selectorLabels | object | `{}` |  |
 | dashboards.grafana.url | string | `""` |  |
 | fullnameOverride | string | `""` |  |

--- a/charts/unpoller/templates/grafana.yaml
+++ b/charts/unpoller/templates/grafana.yaml
@@ -9,9 +9,9 @@ spec:
   external:
     url: http://monitoring-promstack-grafana #Grafana URL
     adminPassword:
-      name: grafana-admin-credentials
+      name: {{ include "unpoller.grafana-secret" . }}
       key: GF_SECURITY_ADMIN_PASSWORD
     adminUser:
-      name: grafana-admin-credentials
+      name: {{ include "unpoller.grafana-secret" . }}
       key: GF_SECURITY_ADMIN_USER
 {{- end }}

--- a/charts/unpoller/values.yaml
+++ b/charts/unpoller/values.yaml
@@ -86,7 +86,7 @@ dashboards:
       existingSecretName: ""
       # When existingSecretName is not provided, username and password must be provided. A new secret will be
       # created with the provided username and password. GF_SECURITY_ADMIN_USER.
-      username: "prom"
+      username: "admin"
       # Password for username, will create field GF_SECURITY_ADMIN_PASSWORD
       password: "prom-operator"
 


### PR DESCRIPTION
Add the V in the prefix as the docker image tag, has actually the V in the tag.
Prepare version 5 of the chart. see #4 
Fix the secret name for the Grafana chart, from the static local copy to the actual name generated in the chart. 
update grafana username and password to the default ones in prometheus kube stack helm chart. (will work on default installations).

Note: I pushed few commits in main by mistake, I was trying to fix it in my repo where I have control over the admin/tokens.