### PR TITLE
fix(chart): fix the readiness probe name + release chart6

### DIFF
--- a/charts/unpoller/Chart.yaml
+++ b/charts/unpoller/Chart.yaml
@@ -14,7 +14,7 @@ description: |
   **Note**: *This is a best effort to keep this chart working for kubernetes.*
 
 type: application
-version: "2.11.2-Chart5"
+version: "2.11.2-Chart6"
 appVersion: "v2.11.2"
 keywords:
   - unifi

--- a/charts/unpoller/README.md
+++ b/charts/unpoller/README.md
@@ -1,6 +1,6 @@
 # unpoller
 
-![Version: 2.11.2-Chart5](https://img.shields.io/badge/Version-2.11.2--Chart5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.11.2](https://img.shields.io/badge/AppVersion-v2.11.2-informational?style=flat-square)
+![Version: 2.11.2-Chart6](https://img.shields.io/badge/Version-2.11.2--Chart6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.11.2](https://img.shields.io/badge/AppVersion-v2.11.2-informational?style=flat-square)
 
 A Helm chart for unpoller, a unifi prometheus exporter. This chart helps deploy Unpoller (unifi metrics exporter)
 in kubernetes clusters.
@@ -38,14 +38,14 @@ See further documentation in how to install unpoller in Kubernetes in http://unp
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | livenessProbe.httpGet.path | string | `"/"` |  |
-| livenessProbe.httpGet.port | string | `"http"` |  |
+| livenessProbe.httpGet.port | string | `"tcp"` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | readinessProbe.httpGet.path | string | `"/"` |  |
-| readinessProbe.httpGet.port | string | `"http"` |  |
+| readinessProbe.httpGet.port | string | `"tcp"` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |

--- a/charts/unpoller/values.yaml
+++ b/charts/unpoller/values.yaml
@@ -55,11 +55,11 @@ resources: {}
 livenessProbe:
   httpGet:
     path: /
-    port: http
+    port: tcp
 readinessProbe:
   httpGet:
     path: /
-    port: http
+    port: tcp
 
 nodeSelector: {}
 


### PR DESCRIPTION
Fix the port name for the readiness probe http => tcp
Update release for chart => 2.11.2-Chart6
Generate docs.

I think version will be stable. It would be great if there's a new release of unpoller so we can test also the full path of generating the update of the image version.