### PR TITLE
fix(chart): Use build metadata format for chart versions

### DIFF
--- a/.github/workflows/on_unpoller_release.yaml
+++ b/.github/workflows/on_unpoller_release.yaml
@@ -31,12 +31,39 @@ jobs:
       - name: Update helm values
         run: |
           UNPOLLER_VERSION=${{ github.event.inputs.unpoller_version }}
+
+          # Determine the next chart number for this unpoller version
+          # Check existing git tags to find the highest chart number
+          LATEST_CHART_NUM=$(git tag -l "${UNPOLLER_VERSION}+chart*" | sed 's/.*+chart//' | sort -n | tail -1)
+
+          # If no existing chart version found, start with chart1
+          if [ -z "$LATEST_CHART_NUM" ]; then
+            # Also check for old format (with dash) for backwards compatibility
+            LATEST_CHART_NUM=$(git tag -l "${UNPOLLER_VERSION}-Chart*" "${UNPOLLER_VERSION}-chart*" | sed 's/.*-[Cc]hart//' | sort -n | tail -1)
+            if [ -z "$LATEST_CHART_NUM" ]; then
+              CHART_NUM=1
+            else
+              CHART_NUM=$((LATEST_CHART_NUM + 1))
+            fi
+          else
+            CHART_NUM=$((LATEST_CHART_NUM + 1))
+          fi
+
+          CHART_VERSION="${UNPOLLER_VERSION}+chart${CHART_NUM}"
+
+          echo "Setting appVersion to: ${UNPOLLER_VERSION}"
+          echo "Setting version to: ${CHART_VERSION}"
+
           yq -i ".appVersion=\"${UNPOLLER_VERSION}\"" charts/unpoller/Chart.yaml
-          yq -i ".version=\"${UNPOLLER_VERSION}\"" charts/unpoller/Chart.yaml
+          yq -i ".version=\"${CHART_VERSION}\"" charts/unpoller/Chart.yaml
           make helm-docs
-          
+
           cp charts/unpoller/README.md README.MD
           git add charts
-          git add README.MD         
-          git commit -m "chore(unpoller): Updated chart and app version to ${UNPOLLER_VERSION}}"
+          git add README.MD
+          git commit -m "chore(unpoller): Updated chart to ${CHART_VERSION} with app version ${UNPOLLER_VERSION}"
           git push
+
+          # Create and push the tag
+          git tag "${CHART_VERSION}"
+          git push origin "${CHART_VERSION}"


### PR DESCRIPTION
Changes chart versioning from pre-release format (X.Y.Z-ChartN) to build metadata format (X.Y.Z+chartN), making charts discoverable in helm search without --devel flag.

The workflow now:
- Auto-increments chart numbers by checking existing tags
- Uses semver build metadata (+) instead of pre-release identifiers (-)
- Maintains backwards compatibility with old tag format
- Automatically creates and pushes version tags

Fixes #9