### PR TITLE
feat(unpoller): add optional Service and PodMonitor resources

### DIFF
--- a/charts/unpoller/README.md
+++ b/charts/unpoller/README.md
@@ -43,12 +43,17 @@ See further documentation in how to install unpoller in Kubernetes in http://unp
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
+| podMonitor.enabled | bool | `true` | Whether to create a PodMonitor resource for Prometheus Operator. Set to `false` if Prometheus Operator CRDs are not installed. |
 | podSecurityContext | object | `{}` |  |
 | readinessProbe.httpGet.path | string | `"/"` |  |
 | readinessProbe.httpGet.port | string | `"tcp"` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
+| service.annotations | object | `{}` | Additional annotations for the Service (e.g., for Grafana Alloy autodiscovery) |
+| service.enabled | bool | `false` | Whether to create a Service resource |
+| service.port | int | `9130` | Service port for metrics endpoint |
+| service.type | string | `"ClusterIP"` | Service type (ClusterIP, NodePort, LoadBalancer) |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.automount | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/unpoller/templates/pod-monitor.yaml
+++ b/charts/unpoller/templates/pod-monitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.podMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -10,3 +11,4 @@ spec:
       {{- include "unpoller.selectorLabels" . | nindent 6 }}
   podMetricsEndpoints:
     - port: tcp
+{{- end }}

--- a/charts/unpoller/templates/service.yaml
+++ b/charts/unpoller/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "unpoller.fullname" . }}
+  labels:
+    {{- include "unpoller.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: tcp
+      protocol: TCP
+      name: tcp
+  selector:
+    {{- include "unpoller.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/unpoller/values.yaml
+++ b/charts/unpoller/values.yaml
@@ -67,6 +67,22 @@ tolerations: []
 
 affinity: {}
 
+# Service configuration
+service:
+  # Whether to create a Service resource
+  enabled: false
+  # Service type (ClusterIP, NodePort, LoadBalancer)
+  type: ClusterIP
+  # Service port for metrics endpoint
+  port: 9130
+  # Additional annotations for the Service (e.g., for Grafana Alloy autodiscovery)
+  annotations: {}
+
+# PodMonitor configuration for Prometheus Operator
+podMonitor:
+  # Whether to create a PodMonitor resource for Prometheus Operator
+  enabled: true
+
 # section to configure he unpoller dashboards, relaying on the CRDs from grafana operator. https://github.com/grafana/grafana-operator
 dashboards:
   create: true


### PR DESCRIPTION
This change adds flexibility to the Unpoller Helm chart by making monitoring resources optional.

Changes:
- Added podMonitor.enabled flag (default: true)
  - Wraps PodMonitor template in conditional
  - Prevents errors on clusters without Prometheus Operator CRDs

- Added service.enabled flag (default: false)
  - Creates new Service resource for metrics endpoint
  - Supports Grafana Alloy autodiscovery via annotations
  - Defaults to false to maintain backward compatibility

- Updated values.yaml with new configuration options
- Updated README.md with parameter documentation

Breaking Changes: None (backward compatible defaults)

Use Cases:
- Clusters without Prometheus Operator (set podMonitor.enabled: false)
- Grafana Alloy monitoring (set service.enabled: true)