### PR TITLE
Rework application configuration

### DIFF
--- a/charts/unpoller/Chart.yaml
+++ b/charts/unpoller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: unpoller
 description: "A Helm chart for unpoller, a unifi prometheus exporter. This chart helps deploy Unpoller (unifi metrics exporter)\nin kubernetes clusters. \nIt crates a Deployment to run the unpoller container, confiuration is stored in a ConfigMap and mounted in the container.\nIt supports integration with Prometheus operator, so a PodMonitor is created that will scrape the Deployment for the metrics.\nOptionally, it can deploy automatically the dashboards into a Grafana instance through the integration with GrafanaOperator:\n* Creates a Grafana CR with the credentials provided (or reuses existing Grafana object)\n* Creates a Dashboard instance for all the unpoller provided charts.\n\nSee further documentation in how to install unpoller in Kubernetes in http://unpoller.github.io/helm-chart \n\n**Note**: *This is a best effort to keep this chart working for kubernetes.*\n"
 type: application
-version: "2.1.0"
+version: "3.0.0"
 appVersion: "v2.21.0"
 keywords:
   - unifi

--- a/charts/unpoller/README.md
+++ b/charts/unpoller/README.md
@@ -1,6 +1,6 @@
 # unpoller
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.21.0](https://img.shields.io/badge/AppVersion-v2.21.0-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.21.0](https://img.shields.io/badge/AppVersion-v2.21.0-informational?style=flat-square)
 
 A Helm chart for unpoller, a unifi prometheus exporter. This chart helps deploy Unpoller (unifi metrics exporter)
 in kubernetes clusters.
@@ -25,6 +25,24 @@ See further documentation in how to install unpoller in Kubernetes in http://unp
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| config.influxdb.disable | bool | `true` |  |
+| config.loki.disable | bool | `true` |  |
+| config.poller.debug | bool | `false` |  |
+| config.poller.plugins | list | `[]` |  |
+| config.poller.quiet | bool | `false` |  |
+| config.prometheus.disable | bool | `false` |  |
+| config.prometheus.http_listen | string | `"0.0.0.0:9130"` |  |
+| config.prometheus.report_errors | bool | `false` |  |
+| config.unifi.defaults.hash_pii | bool | `false` |  |
+| config.unifi.defaults.pass | string | `"unifi"` |  |
+| config.unifi.defaults.save_dpi | bool | `true` |  |
+| config.unifi.defaults.save_ids | bool | `true` |  |
+| config.unifi.defaults.save_sites | bool | `true` |  |
+| config.unifi.defaults.sites[0] | string | `"all"` |  |
+| config.unifi.defaults.url | string | `"https://unifi.home:8443"` |  |
+| config.unifi.defaults.user | string | `"unifi"` |  |
+| config.unifi.defaults.verify_ssl | bool | `false` |  |
+| config.unifi.dynamic | bool | `false` |  |
 | dashboards.create | bool | `true` |  |
 | dashboards.grafana.create | bool | `true` |  |
 | dashboards.grafana.secret.existingSecretName | string | `""` |  |
@@ -32,6 +50,12 @@ See further documentation in how to install unpoller in Kubernetes in http://unp
 | dashboards.grafana.secret.username | string | `"admin"` |  |
 | dashboards.grafana.selectorLabels | object | `{}` |  |
 | dashboards.grafana.url | string | `""` |  |
+| debug | bool | `false` |  |
+| defaultCredentialsExistingSecret.enabled | bool | `false` |  |
+| defaultCredentialsExistingSecret.name | string | `""` |  |
+| defaultCredentialsExistingSecret.passwordKey | string | `"password"` |  |
+| defaultCredentialsExistingSecret.userKey | string | `"user"` |  |
+| extraEnv | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/unpoller/unpoller"` |  |
@@ -59,5 +83,4 @@ See further documentation in how to install unpoller in Kubernetes in http://unp
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
 | tolerations | list | `[]` |  |
-| upConfig | string | `"[poller]\n    debug = false\n    quiet = false\n    plugins = []\n[prometheus]\n  disable = false\n  http_listen = \"0.0.0.0:9130\"\n  report_errors = false\n[influxdb]\n  disable = true\n[unifi]\n    dynamic = false\n[loki]\n    disable = true\n[[unifi.controller]]    \n    url         = \"https://unifi.home:8443\"\n    user        = \"unifi\"\n    pass        = \"unifi\"\n    sites       = [\"all\"]\n    save_ids    = true\n    save_dpi    = true\n    save_sites  = true\n    hash_pii    = false\n    verify_ssl  = false\n"` |  |
 

--- a/charts/unpoller/templates/configmap.yaml
+++ b/charts/unpoller/templates/configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
   name: {{ include "unpoller.fullname" . }}
   labels:
     {{- include "unpoller.labels" . | nindent 4 }}
-stringData:
-  up.conf: |
-    {{- .Values.upConfig | nindent 4}}
+data:
+  up.yaml: |
+    {{- toYaml .Values.config | nindent 4 }}

--- a/charts/unpoller/templates/deployment.yaml
+++ b/charts/unpoller/templates/deployment.yaml
@@ -34,6 +34,24 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: UP_POLLER_DEBUG
+              value: {{ .Values.debug }}
+            {{- if .Values.defaultCredentialsExistingSecret.enabled }}
+            - name: UP_UNIFI_DEFAULT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.defaultCredentialsExistingSecret.name }}
+                  key: {{ .Values.defaultCredentialsExistingSecret.userKey }}
+            - name: UP_UNIFI_DEFAULT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.defaultCredentialsExistingSecret.name }}
+                  key: {{ .Values.defaultCredentialsExistingSecret.passwordKey }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - containerPort: 9130
               name: tcp

--- a/charts/unpoller/templates/deployment.yaml
+++ b/charts/unpoller/templates/deployment.yaml
@@ -34,9 +34,12 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--config"
+            - "/etc/unpoller/up.yaml"
           env:
             - name: UP_POLLER_DEBUG
-              value: {{ .Values.debug }}
+              value: {{ .Values.debug | quote }}
             {{- if .Values.defaultCredentialsExistingSecret.enabled }}
             - name: UP_UNIFI_DEFAULT_USER
               valueFrom:
@@ -67,8 +70,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: config-volume
-              mountPath: /etc/unpoller/up.conf
-              subPath: up.conf
+              mountPath: /etc/unpoller/up.yaml
+              subPath: up.yaml
       volumes:
         - name: config-volume
           secret:

--- a/charts/unpoller/templates/unpoller-config-secret.yaml
+++ b/charts/unpoller/templates/unpoller-config-secret.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ include "unpoller.fullname" . }}
   labels:
     {{- include "unpoller.labels" . | nindent 4 }}
-data:
+stringData:
   up.yaml: |
     {{- toYaml .Values.config | nindent 4 }}

--- a/charts/unpoller/values.yaml
+++ b/charts/unpoller/values.yaml
@@ -38,7 +38,9 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-
+extraEnv: []
+  # - name: UP_POLLER_QUIET
+  #   value: false
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -83,7 +85,7 @@ podMonitor:
   # Whether to create a PodMonitor resource for Prometheus Operator
   enabled: true
 
-# section to configure he unpoller dashboards, relaying on the CRDs from grafana operator. https://github.com/grafana/grafana-operator
+# section to configure the unpoller dashboards, relaying on the CRDs from grafana operator. https://github.com/grafana/grafana-operator
 dashboards:
   create: true
   # Configures the Grafana instance (grafana.integreatly.org/v1beta1)
@@ -106,30 +108,42 @@ dashboards:
       # Password for username, will create field GF_SECURITY_ADMIN_PASSWORD
       password: "prom-operator"
 
-# Configuration file to be loaded by unpoller, See Github example page for more details.
-# https://github.com/unpoller/unpoller/blob/master/examples/up.conf.example
-upConfig: |
-  [poller]
-      debug = false
-      quiet = false
-      plugins = []
-  [prometheus]
-    disable = false
-    http_listen = "0.0.0.0:9130"
-    report_errors = false
-  [influxdb]
-    disable = true
-  [unifi]
-      dynamic = false
-  [loki]
-      disable = true
-  [[unifi.controller]]    
-      url         = "https://unifi.home:8443"
-      user        = "unifi"
-      pass        = "unifi"
-      sites       = ["all"]
-      save_ids    = true
-      save_dpi    = true
-      save_sites  = true
-      hash_pii    = false
-      verify_ssl  = false
+# debug controls whether unpoller debug mode is enabled
+debug: false
+
+# defaultCredentialsExistingSecret is used to inject a default username and password from an
+# existing Kubernetes secret
+defaultCredentialsExistingSecret:
+  enabled: false
+  name: ""
+  userKey: "user"
+  passwordKey: "password"
+
+# config is used to construct the unpoller application config
+# see https://unpoller.com/docs/install/configuration for configuration options
+config:
+  poller:
+    debug: false
+    quiet: false
+    plugins: []
+  prometheus:
+    disable: false
+    http_listen: "0.0.0.0:9130"
+    report_errors: false
+  influxdb:
+    disable: true
+  unifi:
+    dynamic: false
+    defaults:
+      url: "https://unifi.home:8443"
+      user: "unifi"
+      pass: "unifi"
+      sites:
+        - "all"
+      save_ids: true
+      save_dpi: true
+      save_sites: true
+      hash_pii: false
+      verify_ssl: false
+  loki:
+    disable: true


### PR DESCRIPTION
This PR:
* Allows configuration to be built from a helm values map instead of a single string
* Allows using a pre-existing secret to inject credentials (resolves #15)
* Enables adding additional environment variables

I bumped the chart version to 3.0.0 to represent that this is a breaking change, replacing the previous method of injecting application config.