### PR TITLE
Allow extra env

### DIFF
--- a/charts/unpoller/Chart.yaml
+++ b/charts/unpoller/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: unpoller
 description: "A Helm chart for unpoller, a unifi prometheus exporter. This chart helps deploy Unpoller (unifi metrics exporter)\nin kubernetes clusters. \nIt crates a Deployment to run the unpoller container, confiuration is stored in a ConfigMap and mounted in the container.\nIt supports integration with Prometheus operator, so a PodMonitor is created that will scrape the Deployment for the metrics.\nOptionally, it can deploy automatically the dashboards into a Grafana instance through the integration with GrafanaOperator:\n* Creates a Grafana CR with the credentials provided (or reuses existing Grafana object)\n* Creates a Dashboard instance for all the unpoller provided charts.\n\nSee further documentation in how to install unpoller in Kubernetes in http://unpoller.github.io/helm-chart \n\n**Note**: *This is a best effort to keep this chart working for kubernetes.*\n"
 type: application
-version: "2.1.0"
+version: "2.2.0"
 appVersion: "v2.21.0"
 keywords:
   - unifi

--- a/charts/unpoller/templates/deployment.yaml
+++ b/charts/unpoller/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 9130
               name: tcp

--- a/charts/unpoller/values.yaml
+++ b/charts/unpoller/values.yaml
@@ -2,6 +2,10 @@
 
 replicaCount: 1
 
+extraEnv: []
+# - name: ENABLE_SERVER_STORAGE
+#   value: "false"
+
 image:
   repository:  "ghcr.io/unpoller/unpoller"
   pullPolicy: IfNotPresent

--- a/charts/unpoller/values.yaml
+++ b/charts/unpoller/values.yaml
@@ -127,7 +127,7 @@ upConfig: |
       dynamic = false
   [loki]
       disable = true
-  [[unifi.controller]]    
+  [[unifi.controller]]
       url         = "https://unifi.home:8443"
       user        = "unifi"
       pass        = "unifi"


### PR DESCRIPTION
Hello,

I need extra env to allow a parent chart to pass 

```
unpoller:
  extraEnv:
  - name: UP_UNIFI_CONTROLLER_0_URL
    value: "https://unifiunpoller:8443"
  - name: UP_UNIFI_CONTROLLER_0_USER
    valueFrom:
      secretKeyRef:
        name: unifi-metrics-credentials
        key: username
  - name: UP_UNIFI_CONTROLLER_0_PASS
    valueFrom:
      secretKeyRef:
        name: unifi-metrics-credentials
        key: password
```
without needed to edit the configmap containing the "complex" file
