### PR TITLE
feat: support existing secret for upConfig

### DIFF
--- a/charts/unpoller/templates/deployment.yaml
+++ b/charts/unpoller/templates/deployment.yaml
@@ -54,7 +54,14 @@ spec:
       volumes:
         - name: config-volume
           secret:
+            {{- if .Values.upConfigExistingSecret.name }}
+            secretName: {{ .Values.upConfigExistingSecret.name }}
+            items:
+              - key: {{ .Values.upConfigExistingSecret.key }}
+                path: up.conf
+            {{- else }}
             secretName: {{ include "unpoller.fullname" . }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/unpoller/templates/unpoller-config-secret.yaml
+++ b/charts/unpoller/templates/unpoller-config-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.upConfigExistingSecret.name }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 stringData:
   up.conf: |
     {{- .Values.upConfig | nindent 4}}
+{{- end }}

--- a/charts/unpoller/values.yaml
+++ b/charts/unpoller/values.yaml
@@ -106,6 +106,11 @@ dashboards:
       # Password for username, will create field GF_SECURITY_ADMIN_PASSWORD
       password: "prom-operator"
 
+# Use an existing secret for up.conf. When name is set, upConfig is ignored and no secret is created.
+upConfigExistingSecret:
+  name: ""
+  key: "up.conf"
+
 # Configuration file to be loaded by unpoller, See Github example page for more details.
 # https://github.com/unpoller/unpoller/blob/master/examples/up.conf.example
 upConfig: |


### PR DESCRIPTION
Add optional `upConfigExistingSecret.{name,key}` values so users can supply the up.conf contents via a pre-existing Kubernetes Secret. When name is set, the chart skips creating its own config Secret and the deployment mounts the referenced secret/key as up.conf. Default behavior (rendering upConfig into a chart-managed Secret) is unchanged.